### PR TITLE
Investigate kelly and ken animation failures

### DIFF
--- a/complete-lesson-player.js
+++ b/complete-lesson-player.js
@@ -659,7 +659,7 @@ class UniversalLessonPlayer {
     }
 
     buildContentFromPhaseDNA(phaseDNA){
-        // Reduce 5 phases into current player’s content interface while we migrate UI fully
+        // Reduce 5 phases into current player's content interface while we migrate UI fully
         const getQ = (id) => {
             const p = phaseDNA.phases.find(x=>x.id===id);
             if (!p) return null;
@@ -752,8 +752,8 @@ class UniversalLessonPlayer {
             }
         }
 
-        // Update avatar for current phase
-        this.updateAvatarForPhase(phase);
+        // Update avatar for current phase (use mapped phase identifier)
+        this.updateAvatarForPhase(mappedPhase);
 
         // If PhaseDNA v1, run direct PhaseRunner and return. Do NOT invoke legacy renderer.
         if (this.currentDNA?.metadata?.version === 'phase_v1') {


### PR DESCRIPTION
Fixes Kelly and Ken animations by passing the correct mapped phase identifier to the avatar update function.

The `updateAvatarForPhase` method expects normalized phase identifiers (e.g., 'welcome', 'beginning'), but the `playCurrentPhase` method was incorrectly passing the raw, unmapped phase value. This caused the avatar to remain in a neutral pose instead of updating its expression according to the current phase.

---
<a href="https://cursor.com/background-agent?bcId=bc-e32578c7-0465-4833-a3c3-954c1c4520fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e32578c7-0465-4833-a3c3-954c1c4520fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

